### PR TITLE
chore: add Hermes Delivery issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/hermes_delivery.yml
+++ b/.github/ISSUE_TEMPLATE/hermes_delivery.yml
@@ -1,0 +1,105 @@
+name: 🛰️ Hermes Delivery
+description: Track a Boss pipeline item (scope → design → build → test → deploy)
+title: "Delivery: "
+labels: [contribution, hermes-pipeline]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Pete AI Org · delivery ticket
+        Opened by the Hermes **build-and-deploy** pipeline (or a specialist skill).
+        Keep this issue updated as the work moves through phases.
+
+  - type: input
+    id: target_repo
+    attributes:
+      label: Target repo
+      description: Where the code change lands (owner/name)
+      placeholder: "petermsouzajr/doodle-do"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: contribution_type
+    attributes:
+      label: Type
+      options:
+        - "✨ Feature"
+        - "🐞 Fix"
+        - "📝 Documentation"
+        - "💻 Refactor"
+        - "🏗️ Infrastructure"
+        - "🔒 Security"
+      default: 0
+    validations:
+      required: true
+
+  - type: textarea
+    id: goal
+    attributes:
+      label: Goal / user outcome
+      description: What should a user be able to do when this is done?
+      placeholder: "Cancel an in-flight feedback send without submitting."
+    validations:
+      required: true
+
+  - type: textarea
+    id: tasks
+    attributes:
+      label: Tasks / acceptance criteria
+      description: Checklist the Implementer and Tester will drive to done
+      value: |
+        Tasks:
+        - [ ] Scope + AC confirmed
+        - [ ] Design handoff (or explicitly skipped)
+        - [ ] PR opened and linked here
+        - [ ] Automated tests / CI green
+        - [ ] Preview URL posted
+        - [ ] Pete manual verification
+        - [ ] Ship / prod (only after Pete says ship it)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: phase
+    attributes:
+      label: Current pipeline phase
+      options:
+        - "1 · Scoped"
+        - "2 · Designed"
+        - "3 · Implementing"
+        - "4 · In review / CI"
+        - "5 · QA / preview"
+        - "6 · Waiting on Pete"
+        - "7 · Shipped"
+        - "⛔ Blocked"
+      default: 0
+    validations:
+      required: true
+
+  - type: textarea
+    id: links
+    attributes:
+      label: Links
+      description: PR, preview, design notes, related issues
+      value: |
+        - PR:
+        - Preview:
+        - Design:
+        - Related:
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Constraints, out of scope, risks
+      placeholder: "MVP only; no email changes."
+
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/petermsouzajr/qa-shadow-report/blob/main/CODE_OF_CONDUCT.md).
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true


### PR DESCRIPTION
## Summary
Adds `🛰️ Hermes Delivery` issue template for the Boss pipeline.

## Why
Central ticket tracking on this repo for feature deliveries driven by Hermes skills.

## Checklist
- [x] Template only; no runtime code changes
